### PR TITLE
Use PR mergeable_state to determine mergeability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # GitHub merger
 A serverless automatic GitHub pull request merger.
 
-This script will utilize GitHub webhooks, AWS lambda and GitHub API to automatically merge approved and tested pull requests.
+This script will utilize GitHub webhooks, AWS lambda and GitHub API to automatically merge pull requests that can be merged according to branch protection settings.
 Setting this up should not take more than 10 minutes, given you have the required access to Github and AWS.
+Make sure your branches are protected and define requirements such as approved reviews and/or check status pass, otherwise PRs will be merged too early.
 
 ## The pain
 Does this seem familiar?
@@ -52,9 +53,13 @@ Does this seem familiar?
             * Use Lambda Proxy integration.
         * Deploy the changes: Actions -> Deploy API.
     * Get the URL by going to `"Stages" -> prod -> POST` and copying the `Invoke URL`.
-5. GitHub Webhook
+5. Branch protection
+    * Under the repository settings, go to `Settings -> Branches`
+    * Add branch protection rules to the desired target branches (such as `master`)
+    * For example you might want to have `Require pull request reviews before merging` and `Require status checks to pass before merging`
+6. GitHub Webhook
     * This can be done on a per-repository or per-account basis. Your call.
-    * Under the account or repository settings, go to Settings -> Webhooks.
+    * Under the account or repository settings, go to `Settings -> Webhooks`.
     * Add a Webhook:
         * Payload URL is the Invoke URL you just copied.
         * Content Type: application/json
@@ -72,7 +77,6 @@ Setting | Required | Meaning
 ------- | -------- | -------
 ALLOWED_REPOS | Yes | A comma-separated list of github repositories the script is allowed to be executed on (use `*` for everything).
 GITHUB_TOKEN | Yes | The GitHub API token you obtained in setup 2 of Setup.
-REQUIRED_CONTEXT | No | The source of a required build (default: `continuous-integration/travis-ci/pr`)
 GITHUB_SECRET | No | A secret configured in the GitHub webhook configuration. If configured, incoming requests will be validated using it.
 TITLE_INDICATOR | No | An indicator within the Pull Request's title to *allow* automatic merging. Default: `[AM]` (case insensitive). Use * to allow everything.
 TITLE_PREVENTOR | No | An indicator within the Pull Request's title to *block* automatic merging. Default: `[DM]` (case insensitive). Set to an empty string to allow everything.

--- a/func.py
+++ b/func.py
@@ -32,7 +32,7 @@ def required_context():
 
 def git_review_handler(event, _context):
     logging.debug(event)
-    webhook = github_webhook.Webhook(event['body'], event['headers'], get_environment_var('GITHUB_SECRET', True))
+    webhook = github_webhook.Webhook(event['body']['payload'], event['headers'], get_environment_var('GITHUB_SECRET', True))
     if not webhook.is_valid_request():
         return response(404, 'not found')
     j = webhook.event

--- a/func.py
+++ b/func.py
@@ -11,7 +11,6 @@ from auto_merger import GitAutoMerger
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
-DEFAULT_CONTEXT = 'continuous-integration/travis-ci/pr'
 ENCRYPTED_KEYS = ('GITHUB_SECRET', 'GITHUB_TOKEN')
 
 
@@ -26,10 +25,6 @@ def response(status_code, status):
     return {'statusCode': status_code, 'body': status}
 
 
-def required_context():
-    return os.environ.get('REQUIRED_CONTEXT', DEFAULT_CONTEXT)
-
-
 def git_review_handler(event, _context):
     logging.debug(event)
     webhook = github_webhook.Webhook(event['body']['payload'], event['headers'], get_environment_var('GITHUB_SECRET', True))
@@ -40,56 +35,34 @@ def git_review_handler(event, _context):
     am = GitAutoMerger(get_environment_var('GITHUB_TOKEN', True))
     if 'ping' == webhook.event_name:
         return response(200, 'grass tastes bad')
+
+    elif 'check_suite' == webhook.event_name:
+        am.repo = j['repository']['full_name']
+        am.sha = j['check_suite']['head_sha']
+        am.branch = j['check_suite']['head_branch']
+
     elif 'status' == webhook.event_name:
-        repo = j['name']
-        sha = j['sha']
-        if not (j['state'] == 'success'):
-            logging.info("Got state %s", j['state'])
-            return response(200, 'Bad state ' + j['state'])
-        if not (j['context'] == required_context()):
-            logging.info("Got context %s", j['context'])
-            return response(200, 'Bad context ' + j['context'])
+        am.repo = j['name']
+        am.sha = j['sha']
+
         if not (len(j['branches']) == 1):
             logging.info("Got branches %s", j['branches'])
             return response(200, 'More than one branch')
+
         branches = j['branches']
-        branch_name = branches[0]['name']
-        logging.info("Starting for %s (%s), branch %s", repo, sha, branch_name)
+        am.branch = branches[0]['name']
 
-        am.repo = repo
-        am.sha = sha
-        am.branch = branch_name
-    elif 'check_suite' == webhook.event_name:
-        repo = j['repository']['full_name']
-        check_suite = j['check_suite']
-        sha = check_suite['head_sha']
-        if j['action'] != 'completed':
-            logging.info("Got state %s", j['action'])
-            return response(200, 'Not completed. status: ' + j['action'])
-        if check_suite['conclusion'] != 'success':
-            logging.info("Got conclusion %s", check_suite['conclusion'])
-            return response(200, 'Bad conclusion ' + check_suite['conclusion'])
-        branch_name = check_suite['head_branch']
-        logging.info("Starting for %s (%s), branch %s", repo, sha, branch_name)
-
-        am.repo = repo
-        am.sha = sha
-        am.branch = branch_name
     elif 'pull_request_review' == webhook.event_name:
-        if not (j['action'] == 'submitted'):
-            logging.info("Got action %s", j['action'])
-            return response(200, 'Bad action ' + j['action'])
-        if not (j['review']['state'] == 'approved'):
-            logging.info("Got state %s", j['review']['state'])
-            return response(200, 'Bad state ' + j['review']['state'])
         pr = j['pull_request']
         am.repo = pr['head']['repo']['full_name']
         am.sha = pr['head']['sha']
         am.pr_id = pr['number']
-        am.pr = pr
         am.branch = pr['head']['ref']
+
     else:
         return response(403, 'unsupported event ' + event)
+
+    logging.info("Starting for %s (%s), branch %s", am.repo, am.sha, am.branch)
 
     try:
         am.auto_merge()

--- a/github_webhook.py
+++ b/github_webhook.py
@@ -13,7 +13,7 @@ class Webhook(object):
         self.event_name = headers.get('X-GitHub-Event')
 
     def is_valid_request(self):
-        if self.secret is None:
+        if not self.secret:
             return True
 
         signature = self.headers.get('X-Hub-Signature')


### PR DESCRIPTION
Fix #15 

This will replace the internal custom logic of pr merger with a simpler one that only checks whether PR is mergeable according to the target branch protection settings, that is when the merge button in the web UI is green, aka `mergeable_state == "clean"`.

**NOTE**: PRs will now automatically be merged at the first received webhook unless branch protection for the destination branch requires approved reviews and or status check passes. This has been documented in the readme.

I added some other minor fixes as the lambda was failing for me:

- with `GITHUB_SECRET` not set (possibly because in that case `self.secret` is `""` and not `None`)
- loading the event (apparentely the body of the event is in `event['body']['payload']` and not `event['body']`

If you want I can update the lambda to work with Python 3.8 (as 2.7 ends support at the end of this year): this will make event loading better (as you don't need to use json loads, the event is already an object).  